### PR TITLE
linkFileProcessor and sgmy2inlets contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # HemePure_tools
+
+- This package is distributed unter a 3-part BSD License. Please see the files LICENSE and THIRD_PARTY_LICENSES for terms and copyright attributions.
+
 - Repository contains tools for HemeLB geometry generation and stuff.
 
 - requires geometry in *.stl format with in/outlets open (think pipe) and inward oriented normals

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -1,0 +1,16 @@
+Third Party Copyright and Licensing
+===================================
+
+In addition to the LICENSE file, the following attributions are made to 3rd
+party developers. These notices must be included in any redistribution or derived
+work of this package in either source code or binary form. Other than the requirement
+to disribute this file, as described above, the terms in the LICENSE file are unchanged.
+
+
+Attribution: Copyright 2024 NVIDIA Corporation
+============
+Contributions to: 
+    - linkFileProcessor directory and files therein
+    - gmy2inlets directory an files therein
+    - modifications to hemeLBpreprocSingle.py (resulting in hemeLBpreprocSingleNewTools.py)
+

--- a/gmy2inlets/Makefile
+++ b/gmy2inlets/Makefile
@@ -1,9 +1,23 @@
-#gmy2hgb: gmy2inlets.cc
-#	g++ -O3 -Wall gmy2inlets.cc -lz -o gmy2inlets
-#debug: gmy2inlets.cc
-#	g++ -g gmy2inlets.cc -lz -o gmy2inlets
+# Copyright 2024 NVIDIA Corporation.
+# For Copyright and Licensing please refer to the LICENSE and
+# THIRD_PARTY_LICENSES file in the top level directory of this package
 
-gmy2hgb: gmy2lets.cc
-	g++ -O3 -Wall gmy2lets.cc -lz -o gmy2lets
-debug: gmy2lets.cc
-	g++ -g gmy2lets.cc -lz -o gmy2lets
+all: gmy2lets sgmy2lets
+
+debug: gmy2lets_debug sgmy2lets_debug
+
+clean:
+	rm -f gmy2lets sgmy2lets
+	
+gmy2lets: gmy2lets.cc
+	g++ -O3 -Wall -I/usr/include/tirpc gmy2lets.cc -lz -ltirpc -o gmy2lets
+
+gmy2lets_debug: gmy2lets.cc
+	g++ -Wall -g -I/usr/include/tirpc gmy2lets.cc -lz -ltirpc -o gmy2lets
+
+sgmy2lets: sgmy2lets.cc
+	g++ -O3 -Wall -I/usr/include/tirpc sgmy2lets.cc -lz -ltirpc -o sgmy2lets
+
+sgmy2lets_debug: sgmy2lets.cc
+	g++ -Wall -g -I/usr/include/tirpc sgmy2lets.cc -lz -ltirpc -o sgmy2lets
+

--- a/gmy2inlets/sgmy2lets.cc
+++ b/gmy2inlets/sgmy2lets.cc
@@ -1,0 +1,528 @@
+// Copyright 2024, NVIDIA Corporation.
+// For Copyright and Licensing please refer to the LICENSE and
+// THIRD_PARTY_LICENSES file in the top level directory of this package
+
+#include <zlib.h>
+#include <iostream>
+#include <vector>
+#include <rpc/rpc.h>
+
+#define DEBUG 0 
+
+#if DEBUG==1
+#define DEBUGMSG(...) printf(__VA_ARGS__)
+#else
+#define DEBUGMSG(...)
+#define INFOMSG(...) printf(__VA_ARGS__)
+#endif
+
+using namespace std;
+
+constexpr uint32_t HemeLbMagicNumber = 0x686c6221;
+constexpr uint32_t GmyNativeMagicNumber = 0x676d7905;
+constexpr uint32_t GmyNativeVersionNumber = 1;
+constexpr size_t NonemptyHeaderRecordSize = 32;
+
+struct NonEmptyHeaderRecord {
+  uint64_t   blockNumber;  // 8 bytes
+  uint64_t   fileOffset;   // 8 bytes
+  uint32_t sites;          // 4 bytes
+  uint32_t bytes;           // 4 bytes
+  uint32_t uncompressedBytes; // 4 bytes
+  uint32_t weights;			  // 4 bytes  Total 32 bytes  
+  NonEmptyHeaderRecord() : blockNumber(0), fileOffset(0),
+						   sites(0), bytes(0), uncompressedBytes(0),
+						   weights(0) { }
+};
+
+
+
+
+struct OutputPreambleInfo {
+  uint32_t HemeLBMagic;
+  uint32_t GmyNativeMagic;
+
+  uint32_t Version;
+  uint32_t BlocksX;
+
+  uint32_t BlocksY;
+  uint32_t BlocksZ;
+
+  uint32_t BlockSize;
+  uint32_t MaxCompressedBytes;
+
+  uint32_t MaxUncompressedBytes;
+  uint32_t HeaderOffset;
+
+  uint64_t NonEmptyBlocks;
+  uint64_t DataOffset;
+  OutputPreambleInfo() : HemeLBMagic(HemeLbMagicNumber),
+                         GmyNativeMagic(GmyNativeMagicNumber),
+                         Version(GmyNativeVersionNumber),
+                         BlocksX(0), BlocksY(0), BlocksZ(0),
+                         MaxCompressedBytes(0), MaxUncompressedBytes(0),
+                         HeaderOffset(56),
+                         NonEmptyBlocks(0),
+                         DataOffset(0) {}
+
+};
+
+
+int64_t xyz_to_i(uint32_t x, uint32_t y, uint32_t z, uint32_t maxX, uint32_t maxY,  uint32_t maxZ)
+{
+  if(x < 0 || x >= maxX || y < 0 || y >= maxY || z < 0 || z >=maxZ) {
+    return -1;
+  }
+  return int64_t(x)*int64_t(maxY)*int64_t(maxZ) + int64_t(y)*int64_t(maxZ) + int64_t(z);
+}
+
+void unique_to_xyz(int64_t unique, uint32_t *X, uint32_t *Y, uint32_t *Z, uint32_t maxX, uint32_t maxY, uint32_t maxZ)
+{
+  *Z = unique%maxZ;
+  int64_t temp = unique/maxZ;
+  *Y = temp%maxY;
+  *X = temp/maxY;
+}
+
+int write_uint(FILE* file, uint32_t value) {
+  int rv = fwrite(&value,4,1,file);
+
+  return rv;
+}
+int read_uint(FILE* file, uint32_t* value) {
+  int rv = fread(value,4,1,file);
+
+  return rv;
+}
+
+
+int sgmy2lets(char *fname_sgmy, char *fname_inlets, bool find_inlets)
+{
+  // gmy file handle
+  FILE *sgmyFile;
+  
+  // xdr block data / memory stream
+  XDR xdrbs;
+
+  // iterator
+  uint64_t i;
+  // return value
+  uint32_t ret;
+
+  // Declarations for the header information
+  uint32_t xBlockCount;
+  uint32_t yBlockCount;
+  uint32_t zBlockCount;
+  uint32_t blockEdgeLen;
+  uint32_t maxCompressedBytes;
+  uint32_t maxUncompressedBytes;
+  uint64_t nonEmptyBlocks; 
+
+  // Data calculated from header information
+  // uint32_t totalBlockCount -- we won't need this it is
+  // just the nonEmptyBlocks we care about
+
+  uint32_t maxSitesPerBlock;
+
+  // Declarations for the block information header
+  std::vector<NonEmptyHeaderRecord> headerInfo;
+
+  // Declarations for zlib decompression
+  z_stream strm;
+  std::vector<unsigned char> compressedBuffer; 
+  std::vector<unsigned char> decompressedBuffer; 
+
+  // Declarations for site information 
+  uint32_t siteIsSimulated;
+  uint32_t linkType;
+  uint32_t siteType;
+  float wallDistance;
+  uint32_t configEntry;
+  uint32_t hasWallNormal;
+  float xWallNormal, yWallNormal, zWallNormal;
+
+  uint32_t blockX = 0, blockY = 0, blockZ = 0;
+  uint32_t localX = 0, localY = 0, localZ = 0;
+ // uint32_t globalX = 0, globalY = 0, globalZ = 0;
+
+  // Stuff needed for hgb
+  uint64_t globalSiteCounter = 0;
+
+  // Allocations to XDR_DECODE from file stream
+  sgmyFile = fopen(fname_sgmy, "r");
+
+  // Open output inlets file
+  FILE *outfile = NULL;
+  if((outfile = fopen(fname_inlets, "w")) == NULL) {
+	fprintf(stderr, "Could not open %s for writing. Aborting.\n", fname_inlets);
+	return 100;
+  }
+
+  // Allocations for simple zlib decompression
+  strm.zalloc = Z_NULL;
+  strm.zfree = Z_NULL;
+  strm.opaque = Z_NULL;
+
+  OutputPreambleInfo preamble;
+  ret = fread(&preamble, preamble.HeaderOffset, 1, sgmyFile);
+  xBlockCount = preamble.BlocksX;
+  yBlockCount = preamble.BlocksY;
+  zBlockCount = preamble.BlocksZ;
+  blockEdgeLen = preamble.BlockSize;
+  maxCompressedBytes = preamble.MaxCompressedBytes;
+  maxUncompressedBytes = preamble.MaxUncompressedBytes;
+  nonEmptyBlocks = preamble.NonEmptyBlocks;
+
+  // Reading gmy header information
+  DEBUGMSG("hlbMagic = %u\n", preamble.HemeLBMagic);
+  DEBUGMSG("sgmyMagic = %u\n", preamble.GmyNativeMagic);
+  DEBUGMSG("sgmyVersion = %u\n", preamble.Version);
+  INFOMSG("xBlockCount = %u\n", xBlockCount);
+  INFOMSG("yBlockCount = %u\n", yBlockCount);
+  INFOMSG("zBlockCount = %u\n", zBlockCount);
+  INFOMSG("blockEdgeLen = %u\n", blockEdgeLen);
+  INFOMSG("maxCompressedBytes = %u\n", maxCompressedBytes);
+  INFOMSG("maxUncompressedBytes = %u\n", maxUncompressedBytes);
+  INFOMSG("nonEmptyBlocks = %lu\n", nonEmptyBlocks);
+
+  // Calculating the number of blocks filling the complete volume
+  // totalBlockCount = xBlockCount * yBlockCount * zBlockCount;
+  
+  // Calculating the maximum number of sites per block
+  maxSitesPerBlock = blockEdgeLen * blockEdgeLen * blockEdgeLen;
+  
+  // Allocating arrays to read block header information
+  headerInfo.resize( nonEmptyBlocks );
+  
+  // blockDataOffset = malloc(totalBlockCount * 3 * sizeof(uint32_t));  
+  // blockDataOffset[0] = (8 + totalBlockCount * 3 ) * sizeof(uint32_t);
+
+  // Reading block header information to arrays
+  uint64_t num_inlets_found = 0;
+  uint64_t num_entries = 0;
+  i=0;
+  while (i<nonEmptyBlocks) {
+
+    ret = fread(&headerInfo[i], NonemptyHeaderRecordSize, 1, sgmyFile);
+    auto& currBlock = headerInfo[i];
+    
+    DEBUGMSG("Block[%lu] ID: %lu\n", i, currBlock.blockNumber);
+    DEBUGMSG("blockSiteCount = %u\n", currBlock.sites);
+    DEBUGMSG("blockCompressedLen = %u\n", currBlock.bytes);
+    DEBUGMSG("blockUncompressedLen = %u\n", currBlock.uncompressedBytes);
+ 
+    num_entries += currBlock.sites;
+
+    // printf("i: %d %d %d %d\n",i,blockSiteCount[i],blockCompressedLen[i],blockUncompressedLen[i]);
+    // Block data offset can be used to skip directly to blocks / parallel access
+    // blockDataOffset[i+1] = blockCompressedLen[i] + blockDataOffset[i];
+    i++;
+  }
+
+  // Reiterate blocks, this time read actual data sets
+  compressedBuffer.resize(maxCompressedBytes);
+  decompressedBuffer.resize(maxUncompressedBytes);
+
+  for (i=0;i<nonEmptyBlocks; i++) {
+    const auto& currBlock = headerInfo[i];
+
+    DEBUGMSG("Block[%lu] ID : %lu\n", i, currBlock.blockNumber);
+
+    // We need to decompose the block number into blockX, blockY and blockZ
+    // we have xBlockCount, yBlockCount and zBlockCount and we
+    // run as  z then y than x (Z fastest) so:
+    //
+    // blockId = blockZ + zBlockCount*( blockY + yBlockCount*blockX)
+    blockZ = currBlock.blockNumber % zBlockCount;
+    uint64_t tmpYX = currBlock.blockNumber / zBlockCount;
+    blockY = tmpYX % yBlockCount;
+    blockX = tmpYX / yBlockCount;
+
+    // Allocate respective buffers
+    
+
+    // Read compressed block from the file
+	fseek(sgmyFile, preamble.DataOffset + currBlock.fileOffset, SEEK_SET);
+
+    ret = fread(compressedBuffer.data(), currBlock.bytes, 1, sgmyFile);
+
+    // Initialise zlib and check if it is OK
+    ret = inflateInit(&strm);
+    if (ret != Z_OK)
+        printf("Decompression init error for block %lu\n",i); 
+
+    // Specify number of bytes to decompress (inflate in zlib-speech)
+    strm.avail_in = currBlock.bytes;
+    
+    // Specify compressed input buffer
+    strm.next_in = compressedBuffer.data();
+
+    // Specify number of uncompressed bytes expected after decompression (inflate in zlib-speech)
+    // (This is normally used to to read chunks to/from a stream)
+    strm.avail_out = currBlock.uncompressedBytes;
+
+    // Specify compressed output buffer
+    strm.next_out = decompressedBuffer.data();
+
+    // Run zlib decompression and check if it is OK
+    ret = inflate(&strm, Z_FINISH);
+    if (ret != Z_STREAM_END)
+        printf("Decompression error for block %lu\n",i);
+
+    // Finalise/end zlib decompression and check if it is OK
+    ret = inflateEnd(&strm);
+    if (ret != Z_OK)
+        printf("Decompression end error for block %lu\n",i);
+          
+    // Create a new XDR_DECODE stream on decompressed buffer
+    xdrmem_create(&xdrbs, (char *)decompressedBuffer.data(), 
+                    currBlock.uncompressedBytes,XDR_DECODE);
+
+    // Loop through all sites on block
+    uint32_t site = 0;
+    localX = 0;
+    localY = 0;
+    localZ = 0;
+
+    for (site = 0;site < maxSitesPerBlock; site++) {
+        DEBUGMSG("local site index (on block): %lu\n", site);
+        // Check if inside or outside (aka solid) of the simulation domain
+        xdr_u_int(&xdrbs, &siteIsSimulated);
+        DEBUGMSG("siteIsSimulated=%u\n", siteIsSimulated);
+        if (siteIsSimulated == 1) {
+            DEBUGMSG("globalSiteCounter: %lu\n", globalSiteCounter);
+	        if (globalSiteCounter%100000 == 0) {
+	            printf("Read site %lu of %lu\n",globalSiteCounter,num_entries);
+            }
+
+            // Default type is FLUID = 0
+            siteType = 0;
+
+            uint32_t link = 0;
+            for (link=0;link<26;link++) { // Only consider 26 links (because there is no link to itself)
+                // Check type for every link to our neighbours
+                xdr_u_int(&xdrbs, &linkType);
+                DEBUGMSG("Link %u: linkType = %u\n", link, linkType);
+                switch (linkType) {
+                case 0 :
+                    // linkType = FLUID
+                    DEBUGMSG("Link %u: FLUID - no further data.\n", link);
+                    break;
+                case 1 : 
+                    // linkType = WALL
+                    // Read float of distance from nearest obstacle
+                    xdr_float(&xdrbs, &wallDistance);
+                    DEBUGMSG("Link %u: WALL - wallDistance=%f\n", link, wallDistance);
+                    switch (siteType) {
+                        // Check for combinations of linkTypes to specify combined siteTypes
+                    case 0 : // was FLUID
+                        siteType = 1; // is now WALL
+                        break;
+                    case 1 : // was WALL
+                        siteType = 1; // stays WALL
+                        break;
+                    case 2 : // was INLET
+                        siteType = 4; // is now INLET+WALL
+                        break;
+                    case 3 : // was OUTLET
+                        siteType = 5; // is now OUTLET+WALL
+                        break;
+                    case 4 : // was INLET+WALL
+                        siteType = 4; // stays INLET+WALL
+                        break;
+                    case 5 : // was OUTLET+WALL
+                        siteType = 5; // stays OUTLET+WALL
+                        break;
+                    }
+                    break;
+                case 2 :
+                    // linkType = INLET
+                    // Read float of distance from nearest obstacle
+                    xdr_u_int(&xdrbs, &configEntry);
+                    // Read float of distance from nearest obstacle
+                    xdr_float(&xdrbs, &wallDistance);
+                    DEBUGMSG("Link %u: INLET - configEntry=%u\n", link, configEntry);
+                    DEBUGMSG("Link %u: INLET - wallDistance=%f\n", link, wallDistance);
+                    switch (siteType) {
+                    case 0 : // was FLUID
+                        siteType = 2; // is now INLET
+                        break;
+                    case 1 : // was WALL
+                        siteType = 4;  // is now INLET+WALL
+                        break;
+                    case 2 : // was INLET
+                        siteType = 2; // stays INLET
+                        break;
+                    case 3 : // was OUTLET
+                        siteType = -2; // INLET+OUTLET = Kaputt
+                        break;
+                    case 4 : // was INLET+WALL
+                        siteType = 4; // stays INLET+WALL
+                        break;
+                    case 5 : // was OUTLET+WALL
+                        siteType = -2; // INLET+OUTLET = Kaputt
+                        break;
+                    }
+                    break;
+                case 3 :
+                    // linkType = OUTLET
+                    // Read index of associated configuration in config.xml
+                    xdr_u_int(&xdrbs, &configEntry);
+                    // Read float of distance from nearest obstacle
+                    xdr_float(&xdrbs, &wallDistance);
+                    DEBUGMSG("Link %u: OUTLET - configEntry=%u\n", link, configEntry);
+                    DEBUGMSG("Link %u: OUTLET - wallDistance=%f\n", link, wallDistance);
+                    switch (siteType) {
+                    case 0 : // was FLUID
+                        siteType = 3; // is now OUTLET
+                        break;
+                    case 1 : // was WALL
+                        siteType = 5; // is now OUTLET+WALL
+                        break;
+                    case 2 : // was INLET
+                        siteType = -2; // INLET+OUTLET = Kaputt
+                        break;
+                    case 3 : // was OUTLET
+                        siteType = 3; // stays OUTLET
+                        break;
+                    case 4 : // was INLET+WALL
+                        siteType = -2; // INLET+OUTLET = Kaputt
+                        break;
+                    case 5 : // was OUTLET+WALL
+                        siteType = 5; // stays OUTLET+WALL
+                        break;              
+                    }
+                    break;
+
+                default:
+                    printf("Unrecognised linkType %u\n", linkType);
+                    exit(1);
+                }
+            } // link loop
+
+	        uint32_t globalX = 0, globalY = 0, globalZ = 0;
+            globalX = blockX * blockEdgeLen + localX;
+            globalY = blockY * blockEdgeLen + localY;          
+            globalZ = blockZ * blockEdgeLen + localZ;
+
+            // Check if there are wall normal coordinates to be read
+            xdr_u_int(&xdrbs, &hasWallNormal);
+            DEBUGMSG("hasWallNormal=%u\n", hasWallNormal);
+            if (hasWallNormal == 1) {
+                // Read wall normal coordinates as separate floats
+                xdr_float(&xdrbs, &xWallNormal);
+                xdr_float(&xdrbs, &yWallNormal);
+                xdr_float(&xdrbs, &zWallNormal);
+                DEBUGMSG("xWallNormal=%f\n", xWallNormal);
+                DEBUGMSG("yWallNormal=%f\n", yWallNormal);
+                DEBUGMSG("zWallNormal=%f\n", zWallNormal);
+            } else if (hasWallNormal != 0) {
+                printf("hasWallNormal has some messed up value, bro. (%u)\n", hasWallNormal);
+                exit(1);
+            }
+
+
+	        if (find_inlets){
+		        // Check if site is inlet
+		        if(siteType == 2 || siteType == 4) {
+			        num_inlets_found += 1;
+			        fprintf(outfile, "%d %d %d %d %d\n", globalX, globalY, globalZ, siteType, configEntry);
+		 
+			        //printf("OUTLET - configEntry=%u\n", configEntry);
+			        //printf("OUTLET - wallDistance=%f\n", wallDistance);
+		 
+		        }
+	        } 
+            else {
+		        // Check if site is outlet
+		        if(siteType == 3 || siteType == 5) {
+			        num_inlets_found += 1;
+			        fprintf(outfile, "%d %d %d %d %d\n", globalX, globalY, globalZ, siteType, configEntry);
+		 
+			        //printf("OUTLET - configEntry=%u\n", configEntry);
+			        //printf("OUTLET - wallDistance=%f\n", wallDistance);
+		 
+		        }
+
+	        }
+
+            globalSiteCounter += 1;
+          //          site += 1;
+        } else {
+          // a solid site does not need a site type
+          siteType = -1;
+        }
+       
+        localZ += 1;
+        if(localZ == blockEdgeLen) {
+            localZ = 0;
+            localY += 1;
+            if(localY == blockEdgeLen) {
+                localY = 0;
+                localX += 1;
+            }
+        }
+        
+    } // site loop      
+    
+    
+    // Destroy the XDR_DECODE stream on decompressedBuffer
+    xdr_destroy(&xdrbs);     
+  }
+  
+  if (find_inlets){
+      printf("Found %lu inlet sites.\n", num_inlets_found);
+  } else {
+
+      printf("Found %lu outlet sites.\n", num_inlets_found);
+  }
+  // Free arrays used to store block header information
+  headerInfo.clear();
+
+  // free(blockDataOffset);
+
+
+  // Close the gmy file handle
+  fclose(sgmyFile);
+  fclose(outfile);
+
+  return 1;
+}
+
+
+
+int main(int argc, char **argv)
+{
+  if (argc == 4) {
+
+    char *fname_sgmy = argv[1];
+    char *fname_inlets = argv[2];
+ 
+    bool find_inlets;
+    std::string action = argv[3];
+    if (action == "INLET") {
+        find_inlets = true;
+    } else if (action == "OUTLET") {
+        find_inlets = false;
+    } else {
+        // Report invalid argument
+        fputs("Invalid boundary indicator:INLET or OUTLET\n", stderr);
+        return 1;
+    }
+
+
+
+
+    int ret = sgmy2lets(fname_sgmy, fname_inlets, find_inlets);
+    if (ret != 1) {
+      return 1;
+    }
+    return 0;
+  }
+  /* otherwise, report usage */
+  else {
+    fputs("Usage: sgmy2lets infile.gmy outfile.inlets doInlets\n", stderr);
+    return 1;
+  }
+}
+

--- a/hemeLBpreprocSingleNewTools.py
+++ b/hemeLBpreprocSingleNewTools.py
@@ -1,0 +1,254 @@
+# Copyright 2024, NVIDIA Corporation.
+# For Copyright and Licensing please refer to the LICENSE and
+# THIRD_PARTY_LICENSES file in the top level directory of this package
+
+
+import os, sys
+import numpy as np
+
+VOXELIZERPATH = "./execs/voxelizer_MultiInput"
+MAKEGMYMPIPATH = "./execs/make_gmy_MPI.sh"
+VX2GMYPATH = "./execs/linkFileProcessor"
+
+GMY2LETSPATH = "./execs/sgmy2lets"
+INFLOWPROFILEBUILDERPATH = "./execs/inflow-profile-builder/inflow_named3.py"
+
+VX2GMY_CHUNKSIZE = 10000
+
+def execute(command):
+        print("Executing: " + command)
+        r = os.system(command)
+        if r != 0:
+                sys.exit("Command failed.")
+
+def transform_to_lattice(pos, dx, shifts):
+    return pos/dx + shifts
+
+def transform_to_physical(pos, dx, shifts):
+    return dx*(pos - shifts)
+
+def write_voxelizer_xml(xmlfname, dxREL, dxABS, STLFNAME, inletposlist, outletposlist):
+    xml = '<?xml version="1.0" ?>\n<!-- the referenceDirection is used for the resolution -->\n<!-- see src/offLattice/triangularSurfaceMesh.hh -->\n<!-- 0 means x-direction, 1 means y-direction and 2 means z-direction -->\n<referenceDirection> 0 </referenceDirection>\n'
+    xml += "<resolution> " + str(dxREL) + " </resolution>\n"
+    xml += "<DX> " + str(dxABS) + " </DX>\n"
+    xml += "<!-- *.stl containing geometry -->\n"
+    xml += "<stl> " + STLFNAME + " </stl>\n"
+    xml += "<!-- analysis points for identification of iolets -->\n<!-- first <num_Ilets> points identify inlets -->\n<!-- last <num_Olets> points identify outlets -->\n<analysisPoints> <!-- lattice units -->\n"
+    xml += "<numIlets> " + str(len(inletposlist)) + " </numIlets>\n"
+    xml += "<numOlets> " + str(len(outletposlist)) + " </numOlets>\n"
+
+    iolet = 1
+    for pos in inletposlist:
+        xml += '<point id="'+str(iolet)+'"> '
+        xml += str(pos[0]) + ' ' + str(pos[1]) + ' ' + str(pos[2])
+        xml += ' </point>\n'
+        iolet += 1
+    for pos in outletposlist:
+        xml += '<point id="'+str(iolet)+'"> '
+        xml += str(pos[0]) + ' ' + str(pos[1]) + ' ' + str(pos[2])
+        xml += ' </point>\n'
+        iolet += 1
+    xml += "</analysisPoints>\n"
+
+    with open(xmlfname, "w") as outxml:
+        outxml.write(xml)
+
+def write_heme_xml(tauValue, hemexmlfname, gmyfname, gmy_resolution, ioletsblocktxt, originShift):
+    xml =  "<?xml version=\"1.0\"?>\n"
+    xml += "<hemelbsettings version=\"3\">\n"
+    xml += "  <simulation>\n"
+    xml += "    <step_length units=\"s\" value=\"" + str((tauValue - 0.5)*gmy_resolution*gmy_resolution/(12e-6)) + "\"/>\n"
+    xml += "    <steps units=\"lattice\" value=\"CHANGE\"/>\n"
+    xml += "    <stresstype value=\"1\"/>\n"
+    xml += "    <voxel_size units=\"m\" value=\"" + str(gmy_resolution) + "\"/>\n"
+    xml += "    <origin units=\"m\" value=\"(0.0,0.0,0.0)\"/>\n"
+    xml += "  </simulation>\n"
+    xml += " <geometry>\n"
+    xml += "    <datafile path=\"" + gmyfname + "\"/>\n"
+    xml += "  </geometry>\n"
+    xml += "  <initialconditions>\n"
+    xml += "    <pressure>\n"
+    xml += "      <uniform units=\"mmHg\" value=\"0.0\"/>\n"
+    xml += "    </pressure>\n"
+    xml += "  </initialconditions>\n"
+    xml += "  <monitoring>\n"
+    xml += "    <incompressibility/>\n"
+    xml += "  </monitoring>\n\n"
+    xml += ioletsblocktxt + "\n"
+    xml += "  <properties>\n"
+    xml += "   <propertyoutput file=\"inlet.dat\" period=\"100\">\n"
+    xml += "     <geometry type=\"inlet\" />\n"
+    xml += "     <field type=\"velocity\" />\n"
+    xml += "     <field type=\"pressure\" />\n"
+    xml += "   </propertyoutput>\n"
+    xml += "   <propertyoutput file=\"outlet.dat\" period=\"100\">\n"
+    xml += "     <geometry type=\"outlet\" />\n"
+    xml += "     <field type=\"velocity\" />\n"
+    xml += "     <field type=\"pressure\" />\n"
+    xml += "   </propertyoutput>\n"
+    xml += "   <propertyoutput file=\"whole.dat\" period=\"100\">\n"
+    xml += "     <geometry type=\"whole\" />\n"
+    xml += "     <field type=\"velocity\" />\n"
+    xml += "     <field type=\"pressure\" />\n"
+    xml += "   </propertyoutput>\n"
+    xml += "  </properties>\n"
+    xml += "</hemelbsettings>\n";
+
+    with open(hemexmlfname, "w") as outxml:
+        outxml.write(xml)
+
+
+if len(sys.argv) != 10:
+    sys.exit("Usage: python3 hemeLBPreProc.py STLFNAME STLUNITS(e.g 1e-3 for mm) INLETPOSITIONS(X1,Y1,Z1;X2,Y2,Z2;..., (in quotes)) NUMINLETS NUMOUTLETS DXreq NUMRANKS RANKSPERNODE tauDesired")
+
+NUMRANKS = int(sys.argv[-3])
+RANKSPERNODE = int(sys.argv[-2])
+CORESPERRANK=64/RANKSPERNODE
+tauDes = float(sys.argv[-1])
+
+STLFNAME = sys.argv[1]
+STLUNITS = float(sys.argv[2])
+#INLETS = [np.float_(iolet.split(",")) for iolet in (sys.argv[3]).split(";")]
+with open(sys.argv[3]) as inletList:
+    INLETS = [np.float_(iolet.split(",")) for iolet in inletList.readline().split(";")]
+NUMINLETS = int(sys.argv[4])
+NUMOUTLETS = int(sys.argv[5])
+DXreq = np.float64(sys.argv[6])
+
+ROOTNAME = os.path.splitext(os.path.basename(STLFNAME))[0]
+
+print("STLFNAME = ", STLFNAME)
+print("STLUNITS = ", STLUNITS)
+print("INLETS = ", INLETS)
+print("NUMINLETS = ", NUMINLETS)
+print("NUMOUTLETS = ", NUMOUTLETS)
+print("DXreq = ", DXreq)
+
+print("ROOTNAME = ", ROOTNAME)
+
+print("Writing initial xml...")
+xmlfname = ROOTNAME + ".xml"
+
+inletpos0 = [np.array([0.0,0.0,0.0]) for i in range(NUMINLETS)]
+outletpos0 = [np.array([0.0,0.0,0.0]) for i in range(NUMOUTLETS)]
+write_voxelizer_xml(xmlfname, DXreq/STLUNITS, DXreq, STLFNAME, inletpos0, outletpos0)
+
+# Run voxelizer but end early, dumping only the ioletpositions
+execute("mpirun -n " + str(int(NUMRANKS)) + " " + VOXELIZERPATH + " " + xmlfname + "  ENDEARLY\n")
+
+iolet_list = []
+dx = None
+shifts = None
+with open("ioletpositions.txt", "r") as ioletpos:
+    lines = ioletpos.readlines()
+    
+    # Get the real resolution
+    if not lines[0].startswith('DX:'):
+        sys.exit("ioletpositions.txt output from voxelizer does not have DX: line where expected (first line)")
+    dx = float(lines[0].split()[1])
+    print("dx RELATIVE = ", dx)
+    dx = DXreq #dx*STLUNITS
+    print("dx ABSOLUTE = ", dx)
+
+    # Get the shift the voxelizer is applying to the STL
+    if not lines[1].startswith('SHIFTS:'):
+        sys.exit("ioletpositions.txt output from voxelizer does not have DX: line where expected (first line)")
+    shifts = np.array([float(i) for i in lines[1].split()[1:]])
+    print("shifts = ", shifts)
+
+    ioletPosPU = lines[0]
+    ioletPosPU += lines[1]
+    # Get the iolet positions
+    for line in lines[2:]:
+        ioletposFull = [float(i) for i in line.split()]
+        iolet_list.append(np.array(ioletposFull[0:3]))
+        ioletpos = transform_to_physical(np.array(ioletposFull[0:3]),dx,shifts)
+        ioletPosPU += str(ioletpos[0]) + " " + str(ioletpos[1]) + " " + str(ioletpos[2]) + "\n"
+        #ioletPosPU += str(ioletpos[0]) + " " + str(ioletpos[1]) + " " + str(ioletpos[2]) + " " + str(ioletposFull[3]*dx)+ "\n"
+
+with open("ioletpositions_PU.txt", "w") as outxml:
+    outxml.write(ioletPosPU)
+print("Written iolets file in PU, may be handy for inlets text file")
+
+# Work out the inlet positions (provided to this script) in lattice units
+INLETS_LATTICE = [transform_to_lattice(inletpos, dx, shifts) for inletpos in INLETS]
+
+# Identify the closest iolets to the iolet positions passed to this script
+inlets_list = []
+for inletpos in INLETS_LATTICE:
+    min_dist = float("+Inf")
+    favoured_ioindex = -1
+    for ioindex, ioletpos in enumerate(iolet_list):
+        dist = np.linalg.norm(ioletpos - inletpos)
+        if dist < min_dist:
+            min_dist = dist
+            favoured_ioindex = ioindex
+    # Check that the closest inlet is not already in the list (for a different inlet)
+    # This would suggest that the user has entered wrong positions (or two openings are
+    # ridiculously close to each other)
+    if favoured_ioindex in inlets_list:
+        sys.exit("inletpos " + str(inletpos) + " corresponds to more than one 'nearest' opening")
+    inlets_list.append(favoured_ioindex)
+
+print("Identified inlet(s) by index:")
+print(inlets_list)
+
+inletposlist = []
+outletposlist = []
+for ioindex, ioletpos in enumerate(iolet_list):
+
+    # If index is not in list of inlet indices then it's an outlet
+    if ioindex not in inlets_list:
+        outletposlist.append(ioletpos)
+    else:
+        inletposlist.append(ioletpos)
+
+#raise SystemExit(0)
+
+# Write the second version of the voxelizer's xml, in which the inlet and outlet positions are correctly identified and ordered
+write_voxelizer_xml(xmlfname, DXreq/STLUNITS, DXreq, STLFNAME, inletposlist, outletposlist)
+
+# Run voxelizer to completion this time
+execute("mpirun -n " + str(int(NUMRANKS)) + " " + VOXELIZERPATH + " " + xmlfname + "\n")
+
+# Catting many files should no longer be required. The voxelizer should dump just one large file.
+execute("rm -f fluidsAndLinks.plb")
+
+# Write the hemelb input.xml files - with different BCs
+gmyfname = ROOTNAME + ".sgmy"
+gmy_resolution = dx #* STLUNITS
+
+#BCExtensions=["PP","VP","VfP","VfWKf"]
+BCExtensions=["PP"]
+
+for t in range(len(BCExtensions)):
+    hemexmlfname = "input_"+BCExtensions[t]+".xml"
+
+    # Get the inlets and outlets xml blocks (for the hemelb input xml) output by the voxelizer
+    with open("iolets_block_inputxml_"+BCExtensions[t]+".txt", "r") as ioletsblockfile:
+        ioletsblocktxt = ioletsblockfile.read()
+    write_heme_xml(tauDes, hemexmlfname, gmyfname, gmy_resolution, ioletsblocktxt, dx*shifts) #JM had - shiftMaster here
+
+# Convert the voxelizer output into a hemelb gmy file
+execute("mpirun -n " + str(int(NUMRANKS)) + " " + VX2GMYPATH + " ./fluidsAndLinks.dat " + gmyfname+"\n")
+
+## Create the velocity weights file 
+if not os.path.exists('InletImages'):
+    os.mkdir('InletImages')
+inletsfname = ROOTNAME + ".inlets"
+execute(GMY2LETSPATH + " " + gmyfname + " " + inletsfname + " INLET \n")
+execute("python3 " + INFLOWPROFILEBUILDERPATH + " " + inletsfname + " 0 INLET \n")
+
+for ilet in range(0,NUMINLETS): 
+    execute("cp out" + str(ilet) + ".weights.txt INLET" + str(ilet) + "_VELOCITY.txt.weights.txt\n") 
+
+## Create the windkessel weights file 
+if not os.path.exists('OutletImages'):
+    os.mkdir('OutletImages')
+outletsfname = ROOTNAME + ".outlets"
+execute(GMY2LETSPATH + " " + gmyfname + " " + outletsfname + " OUTLET \n")
+execute("python3 " + INFLOWPROFILEBUILDERPATH + " " + outletsfname + " 0 OUTLET \n")
+
+for ilet in range(0,NUMOUTLETS): 
+    execute("cp out" + str(ilet) + ".weights.txt OUTLET" + str(ilet) + "_WK.txt.weights.txt\n") 
+

--- a/linkFileProcessor/Makefile
+++ b/linkFileProcessor/Makefile
@@ -1,0 +1,15 @@
+# Copyright 2024 NVIDIA Corporation.
+# For Copyright and Licensing please refer to the LICENSE and
+# THIRD_PARTY_LICENSES file in the top level directory of this package
+
+CXX=mpicxx
+CXXFLAGS=-O3 -fopenmp -g -ggdb -std=c++17 -I /usr/include/tirpc
+
+all: linkFileProcessor
+
+linkFileProcessor: linkFileProcessor.cpp raw_data_reader.hpp gmy.h
+	$(CXX) $(CXXFLAGS) -o $@ $< -ltirpc -lz
+
+clean:
+	rm -f linkFileProcessor
+

--- a/linkFileProcessor/gmy.h
+++ b/linkFileProcessor/gmy.h
@@ -1,0 +1,74 @@
+// Copyright 2024 NVIDIA Corporation.
+// For Copyright and Licensing please refer to the LICENSE and 
+// THIRD_PARTY_LICENSES file in the top level directory of this package
+
+#ifndef __GMY_H__
+#define __GMY_H__
+
+constexpr uint32_t HemeLbMagicNumber = 0x686c6221;
+constexpr uint32_t GmyMagicNumber = 0x676d7904;
+constexpr uint32_t GmyNativeMagicNumber = 0x676d7905;
+constexpr uint32_t GmyVersionNumber = 4;
+constexpr uint32_t GmyNativeVersionNumber = 1;
+constexpr size_t PreambleBytes = 32;
+
+constexpr size_t HeaderRecordSize = 12;
+
+struct NonEmptyHeaderRecord {
+  uint64_t   blockNumber;  // 8 bytes
+  uint64_t   fileOffset;   // 8 bytes
+  uint32_t sites;          // 4 bytes
+  uint32_t bytes;           // 4 bytes
+  uint32_t uncompressedBytes; // 4 bytes
+  uint32_t weights;			  // 4 bytes  Total 32 bytes  
+  NonEmptyHeaderRecord() : blockNumber(0), fileOffset(0),
+						   sites(0), bytes(0), uncompressedBytes(0),
+						   weights(0) { }
+};
+
+constexpr size_t NonemptyHeaderRecordSize = 32;
+
+struct OutputPreambleInfo {
+  uint32_t HemeLBMagic;
+  uint32_t GmyNativeMagic;
+
+  uint32_t Version;
+  uint32_t BlocksX;
+
+  uint32_t BlocksY;
+  uint32_t BlocksZ;
+
+  uint32_t BlockSize;
+  uint32_t MaxCompressedBytes;
+
+  uint32_t MaxUncompressedBytes;
+  uint32_t HeaderOffset;
+
+  uint64_t NonEmptyBlocks;
+  uint64_t DataOffset;
+  OutputPreambleInfo() : HemeLBMagic(HemeLbMagicNumber),
+                         GmyNativeMagic(GmyNativeMagicNumber),
+                         Version(GmyNativeVersionNumber),
+                         BlocksX(0), BlocksY(0), BlocksZ(0),
+                         MaxCompressedBytes(0), MaxUncompressedBytes(0),
+                         HeaderOffset(56),
+                         NonEmptyBlocks(0),
+                         DataOffset(0) {}
+
+};
+
+struct OutputLink {
+    uint32_t linkType;
+    uint32_t configID;
+    float wallDistance;
+};
+
+struct OutputSite {
+    uint64_t x, y, z;
+    bool hasWallNormal;
+    float normalX, normalY, normalZ;
+    OutputLink links[26];
+};
+
+#endif
+

--- a/linkFileProcessor/linkFileProcessor.cpp
+++ b/linkFileProcessor/linkFileProcessor.cpp
@@ -1,0 +1,891 @@
+// Copyright 2024 NVIDIA Corporation.
+// For Copyright and Licensing please refer to the LICENSE and
+// THIRD_PARTY_LICENSES file in the top level directory of this package
+
+
+#include <cstdio>
+#include <iostream>
+#include <map>
+#include <unordered_map>
+// Needed for easy determination of the 
+// Filesize 
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <cassert>
+#include <cstdlib>
+#include <mpi.h>
+#include <limits>
+#include <array>
+#include <vector>
+#include <set>
+#include <unordered_map>
+#include <algorithm>
+
+#include "raw_data_reader.hpp"
+#include "gmy.h"
+#include <rpc/rpc.h>
+#include <zlib.h>
+
+// This will be my map of blocks to file offsets. 
+
+constexpr uint64_t blockDim = 8;
+constexpr uint64_t blockSites = (blockDim*blockDim*blockDim);
+
+
+
+// The block map is a map from block id to to a vector
+// the vector stores pairs of (site_id, offset in local array)
+
+uint64_t nBlocksX = 0;
+uint64_t nBlocksY = 0;
+uint64_t nBlocksZ = 0;
+int this_rank=0;
+int num_ranks=0;
+std::vector<Site> rearranged_data;
+
+struct ConvertedBlockInfo { 
+	std::array<Site*,blockSites> sites;	
+	NonEmptyHeaderRecord header;
+	ConvertedBlockInfo() {
+		for(int i=0; i < blockSites; i++) sites[i]=nullptr;
+	} 
+};
+
+std::map<size_t, ConvertedBlockInfo> output_info;
+std::vector<char> outbuf;		// Output buffer
+
+void convertData(const std::string& output_filename)
+{
+	double outinfo_starttime = MPI_Wtime();
+	// First set up a map of converted blockinfo 
+	for(int i=0; i < rearranged_data.size(); i++) {
+		Site* current_site = &rearranged_data[i];
+
+		uint64_t x=current_site->x;
+		uint64_t y=current_site->y;
+		uint64_t z=current_site->z;
+		uint64_t blockX = x/ blockDim;
+		uint64_t blockY = y/ blockDim;
+		uint64_t blockZ = z/ blockDim;
+		uint64_t siteX = x % blockDim;
+		uint64_t siteY = y % blockDim;
+		uint64_t siteZ = z % blockDim;
+		uint64_t block_id = blockZ + nBlocksZ * (blockY + nBlocksY * blockX);
+		uint64_t site_id = siteZ + blockDim * (siteY + blockDim * siteX);
+
+		// If we have no block in our map	
+		// Insert an empty vector
+		if( output_info.find( block_id ) == output_info.end() ) {
+			ConvertedBlockInfo binfo;
+			binfo.header.sites = 0;
+			output_info.insert( std::pair<uint64_t, ConvertedBlockInfo >( block_id, binfo) );
+		}
+
+		// We can fill the number of sites
+		ConvertedBlockInfo& binfo = output_info.at(block_id);
+		std::array<Site*,blockSites>& sites = binfo.sites;
+
+		sites[site_id] = current_site ; // Pointer assignment
+		binfo.header.sites++; // Increase the site count for this block
+		binfo.header.blockNumber = block_id; // Insert the block number 
+	}
+
+	// Go through all the blocks and sum all the output sites
+	uint64_t total_output_sites = 0;
+	for( auto& kv : output_info ){
+
+		// Get the block id
+		uint64_t block_id = kv.first;
+
+		// look up the info for the block
+		ConvertedBlockInfo& binfo = output_info.at(block_id);
+
+		// Get the array of site pointers for the block
+		std::array<Site*,blockSites>& the_vec = output_info.at(block_id).sites;
+
+		// Add them to the total site count	
+		total_output_sites += binfo.header.sites;
+	}
+	
+	uint64_t total_sites=0;
+	MPI_Allreduce(&total_output_sites, &total_sites, 1, MPI_UINT64_T,MPI_SUM, MPI_COMM_WORLD);
+	double outinfo_endtime = MPI_Wtime();
+	if ( this_rank == 0 ) {
+		std::cout << "After rebinning: The total number of sites is: " << total_sites
+	 			  << " Rebinning took " << outinfo_endtime - outinfo_starttime <<  " sec. \n";
+	    std::cout << "Starting conversion and compression: \n";
+	}
+	double convert_starttime= MPI_Wtime();
+
+
+	// Now we want to set up buffers for output
+	size_t outbuf_idx = 0;
+
+	// I don't understand this magic number from mpivx2gmy but 
+	// if I replace it with what I think it should be I seem to have weird problems.
+	//	
+	uint64_t max_site_size = (2 + 26 * 4 * sizeof(uint64_t));
+
+	uint64_t max_buffer_size = blockSites * max_site_size;
+	
+	std::vector<unsigned char> outputBuffer( total_output_sites * max_site_size );
+
+	// Now fill the buffer: Traverse the blocks, get the uncompressedSize
+	for( auto& kv : output_info ) {
+		uint64_t block_id = kv.first;	
+		ConvertedBlockInfo& binfo =  output_info.at(block_id);
+		binfo.header.fileOffset = outbuf_idx; // we will need to add the length of the header block to this
+
+		std::array<Site*,blockSites>& the_sites = binfo.sites; // The sites for my block
+		std::array<OutputSite*, blockSites> conv_sites;        // The converted sites
+
+		// For now we set all the converted sites to bet the null pointer
+		for(int i=0; i < blockSites; i++) conv_sites[i]=nullptr;
+
+		// We will need to store the temporary converted sites
+		std::vector<OutputSite> converted; 
+
+		// Travers all the sites
+		for(int i=0; i < blockSites; i++) {
+			Site* site_ptr = the_sites[i];
+
+			// If the site is a fluid site site_ptr is not null
+			if( site_ptr ) {
+				OutputSite newsite;
+				newsite.hasWallNormal = false;
+				newsite.normalX = 0.0;
+				newsite.normalY = 0.0;
+				newsite.normalZ = 0.0;
+				uint32_t num_intersections = 0;
+
+				newsite.x = site_ptr->x;
+				newsite.y = site_ptr->y;
+				newsite.z = site_ptr->z;
+
+				const std::array< std::array< uint64_t, 6>, 26>& ldata = site_ptr-> link_data;
+				for(int linkdir = 0; linkdir < 26; linkdir++) { 
+					const std::array< uint64_t, 6>& dir_ldata = ldata[linkdir];
+					uint64_t lu_wallDistance, lu_normalX, lu_normalY, lu_normalZ, linkType, configID;
+					float wallDistance=0.0, normalX=0.0, normalY=0.0, normalZ=0.0;
+
+					linkType = dir_ldata[0];
+					configID = dir_ldata[1]; 
+					lu_wallDistance = dir_ldata[2]; 
+					lu_normalX = dir_ldata[3];
+					lu_normalY = dir_ldata[4];
+					lu_normalZ = dir_ldata[5];
+
+					newsite.links[linkdir].linkType = (uint32_t)linkType;
+					newsite.links[linkdir].configID = (uint32_t) configID;
+
+					wallDistance = (float)(*(reinterpret_cast<double*>(&lu_wallDistance)));
+					normalX = (float)(*(reinterpret_cast<double*>(&lu_normalX)));
+					normalY = (float)(*(reinterpret_cast<double*>(&lu_normalY)));
+					normalZ = (float)(*(reinterpret_cast<double*>(&lu_normalZ)));
+
+					newsite.links[linkdir].wallDistance = wallDistance;
+
+					// if link is to a wall...
+					if(newsite.links[linkdir].linkType == 1) {
+						newsite.hasWallNormal = true;
+						newsite.normalX += normalX;
+						newsite.normalY += normalY;
+						newsite.normalZ += normalZ;
+						num_intersections++;
+					}
+				}
+
+				if ( newsite.hasWallNormal ) {
+					newsite.normalX /= (float) num_intersections;
+					newsite.normalY /= (float) num_intersections;
+					newsite.normalZ /= (float) num_intersections;
+				}
+
+				converted.push_back(newsite);
+				conv_sites[ i ] = &converted[ converted.size()-1 ];
+			} // if site_ptr
+		} // loop over sites in the block.
+
+		// At this point we can encode the conv_sites to XDR
+		// First we need to work out the uncompressed block length
+
+		// compression and decompression buffers:
+		std::vector<unsigned char> decompressedBuffer(max_buffer_size);
+		std::vector<unsigned char> compressedBuffer(max_buffer_size);
+
+		uint32_t blockUncompressedLen = 0;
+
+		for( int i=0; i < blockSites; i++) { 
+			OutputSite* siteptr = conv_sites[i]; 
+			if( siteptr == nullptr ) { // if solid 
+				blockUncompressedLen += sizeof(uint32_t); // SiteIsSimulated
+			}
+			else { // if fluid
+				blockUncompressedLen += sizeof(uint32_t); // SiteIsSimulated
+				for(uint32_t m = 0; m < 26; m++) {
+					blockUncompressedLen += sizeof(uint32_t); // linkType
+					uint32_t linkType = (*siteptr).links[m].linkType;
+
+					switch ( linkType ) {
+						case 0: // linkType = FLUID (no further data)
+							break;
+						case 1: // linkType = WALL (write distance to nearest obstacle)
+							blockUncompressedLen += sizeof(float); // wallDistance
+							break;
+						case 2:
+							blockUncompressedLen += sizeof(uint32_t); // configEntry
+							blockUncompressedLen += sizeof(float); // wallDistance
+							break;
+						case 3: // linkType = INLET or OUTLET (write config ID and distance to nearest obstacle)
+							blockUncompressedLen += sizeof(uint32_t); // configEntry
+							blockUncompressedLen += sizeof(float); // wallDistance
+							break;
+						default:
+							fprintf(stderr, "ERROR: Unrecognised linkType %u on line %d\n", linkType, __LINE__);
+							MPI_Finalize();
+							exit(1);
+					}
+				}
+				blockUncompressedLen += sizeof(uint32_t); // hasWallNormal
+				if ( siteptr->hasWallNormal ) {
+					blockUncompressedLen += sizeof(float); // normalX
+					blockUncompressedLen += sizeof(float); // normalY
+					blockUncompressedLen += sizeof(float); // normalZ
+				}
+			}
+		}
+		
+		if( blockUncompressedLen > max_buffer_size ) { 
+			std::cout << "Rank " << this_rank << " : blockUncompressedLen= " << blockUncompressedLen  << " < max_buffer_size = " 
+			<< max_buffer_size <<"\n";
+		}
+
+		binfo.header.uncompressedBytes = blockUncompressedLen;
+
+		XDR xdrbs;
+		xdrmem_create(&xdrbs, (char *)decompressedBuffer.data(), blockUncompressedLen, XDR_ENCODE);
+
+		// Encode the block
+		for(int i=0; i < blockSites; i++) {
+			OutputSite* siteptr = conv_sites[i];
+			uint32_t siteIsSimulated = ( siteptr != nullptr ) ? 1 : 0;
+			xdr_u_int(&xdrbs, &siteIsSimulated);
+
+			if( siteIsSimulated == 0 ) continue;
+
+			for( uint32_t link=0; link < 26; link++) {
+
+				// write type of link
+				uint32_t linkType = (*siteptr).links[link].linkType;
+				xdr_u_int(&xdrbs, &linkType);
+				switch (linkType) {
+					case 0: // linkType = FLUID (no further data)
+						break;
+					case 1: // linkType = WALL (write distance to nearest obstacle)
+						xdr_float(&xdrbs, &(siteptr->links[link].wallDistance));
+						break;
+					case 2: // linkType = INLET (write inletID and distance to nearest obstacle
+						xdr_u_int(&xdrbs, &(siteptr->links[link].configID));
+						xdr_float(&xdrbs, &(siteptr->links[link].wallDistance));
+						break;
+					case 3: // linkType = OUTLET (write outletID and distance to nearest obstacle
+						xdr_u_int(&xdrbs, &(siteptr->links[link].configID));
+						xdr_float(&xdrbs, &(siteptr->links[link].wallDistance));
+						break;
+					default:
+						fprintf(stderr, "ERROR: Unrecognised linkType %u on line %d .\n", linkType, __LINE__);
+						MPI_Finalize();
+						exit(1);
+				}
+			}
+
+				// state if there are wall normal coordinates to be read (1 for yes)
+			uint32_t hasWallNormal = (siteptr->hasWallNormal == true)? 1: 0;
+			xdr_u_int(&xdrbs, &hasWallNormal);
+			if (hasWallNormal == 1) {
+				// write wall normal coordinates as separate floats
+				xdr_float(&xdrbs, &(siteptr->normalX));
+				xdr_float(&xdrbs, &(siteptr->normalY));
+				xdr_float(&xdrbs, &(siteptr->normalZ));
+			}
+		}
+
+		xdr_destroy(&xdrbs);
+		// Now we compress
+		z_stream strm;
+
+		// setup zlib for compression
+		strm.zalloc = Z_NULL;
+		strm.zfree = Z_NULL;
+		strm.opaque = Z_NULL;
+
+		// input
+		strm.avail_in = blockUncompressedLen;
+		strm.next_in = decompressedBuffer.data();
+
+		// output
+		strm.avail_out = max_buffer_size;
+		strm.next_out =compressedBuffer.data();
+
+		uint32_t ret;
+		ret = deflateInit(&strm, Z_BEST_COMPRESSION);
+		if(ret != Z_OK) {
+			fprintf(stderr, "ERROR: zlib deflation init.\n");
+			MPI_Finalize();
+			exit(1);
+		}
+		ret = deflate(&strm, Z_FINISH);
+		if (ret != Z_STREAM_END) {
+			fprintf(stderr, "ERROR: Deflation error for block.\n");
+			MPI_Finalize();
+			exit(1);
+		}
+		ret = deflateEnd(&strm);
+		if (ret != Z_OK) {
+			fprintf(stderr, "ERROR: Deflation end error for block.\n");
+			MPI_Finalize();
+			exit(1);
+		}
+
+		// get new compressed size
+		uint32_t blockCompressedLen = (unsigned char*)strm.next_out - compressedBuffer.data();
+		binfo.header.bytes = blockCompressedLen;
+		memcpy(&outputBuffer[outbuf_idx], compressedBuffer.data(), blockCompressedLen);
+		outbuf_idx += blockCompressedLen;
+	} 
+	
+	double convert_endtime=MPI_Wtime(); 
+	if (this_rank == 0 ) std::cout << "Data conversion and compression completed: " << convert_endtime-convert_starttime << " sec.\n";
+
+
+	if (this_rank == 0 ) std::cout << "Gathering information for parallel I/O\n";
+
+	uint64_t rank_compressed_bytes = outbuf_idx;  // This is the total number of compressed data on the local rank
+
+	// Get the total compressed bytes in the file
+	uint64_t total_compressed_bytes = 0;
+
+	// Get the offsets of the compressed data in the file
+	uint64_t compressed_offset = 0;
+
+	// At this point we can get a total file size for the data portion.
+	MPI_Allreduce( &rank_compressed_bytes, &total_compressed_bytes, 1, MPI_INT64_T, MPI_SUM, MPI_COMM_WORLD);
+
+
+	// We can also get the offsets of the data (from the end of the headers) for each rank by performaing an exclusive prefix scan.
+	MPI_Exscan(&rank_compressed_bytes, &compressed_offset, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
+
+	// To fill out the header info we need the maximum compressed and uncompressed bytes as well as total number of non-empty blocks
+	// We may have these already but they are easy to find by traversing out map.
+	uint32_t global_max_uncompressed_bytes = 0;
+	uint32_t global_max_compressed_bytes = 0;
+	uint64_t global_uncompressed_bytes = 0;
+	uint64_t global_compressed_bytes = 0;
+	{
+		// We can compute the maxes of both the uncompressed and copressed in a single loop
+		// then we can do a length 2 MPI Allreduce 
+		uint32_t local_maxes[2] = { 0, 0 };
+		uint64_t local_bytes[2] = { 0, 0 };
+		for( const auto& kv : output_info ) {
+			const auto& header = kv.second.header;
+			local_bytes[0] += (uint64_t)(header.bytes);
+			local_bytes[1] += (uint64_t)(header.uncompressedBytes);
+			if( header.bytes > local_maxes[0] ) local_maxes[0] = header.bytes;
+			if( header.uncompressedBytes > local_maxes[1] ) local_maxes[1] = header.uncompressedBytes;
+		} 
+		uint32_t global_maxes[2] = {0,0}; 
+		uint64_t global_bytes[2] = {(uint64_t)0,(uint64_t)0};
+		MPI_Allreduce(local_maxes, global_maxes, 2, MPI_UINT32_T, MPI_MAX, MPI_COMM_WORLD);
+		global_max_compressed_bytes = global_maxes[0];
+		global_max_uncompressed_bytes = global_maxes[1];
+		MPI_Allreduce(local_bytes, global_bytes, 2, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
+		global_compressed_bytes = global_bytes[0];
+		global_uncompressed_bytes = global_bytes[1];
+	}
+
+	// The number of non empy blocks localy is just the number of elements in output info
+	uint64_t global_nonempty_blocks=0;
+	{	
+		uint64_t local_nonempty_blocks = output_info.size();
+		MPI_Allreduce(&local_nonempty_blocks, &global_nonempty_blocks, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
+	}
+
+	if ( this_rank == 0 ) { 
+		std::cout << "Global Nonempty Blocks = " << global_nonempty_blocks << "\n";
+		std::cout << "Total Uncompressed bytes = " << global_uncompressed_bytes << " = "
+				  << (double)global_uncompressed_bytes/(double)(1024*1024) << " MiB\n";
+
+		std::cout << "Total Compressed bytes = " << total_compressed_bytes << " = "
+				  << (double)total_compressed_bytes/(double)(1024*1024) << " MiB\n"; 
+		std::cout << "Total Compressed bytes 2 = " << global_compressed_bytes << " = "
+				  << (double)global_compressed_bytes/(double)(1024*1024) << " MiB\n";
+		std::cout << "Max Uncomressed bytes (per block) = " << global_max_uncompressed_bytes << " = " 
+				  << (double)global_max_uncompressed_bytes / (double)(1024) << " KiB\n";
+
+		std::cout << "Max Compressed bytes (per block) = " << global_max_compressed_bytes << " = " 
+				  << (double)global_max_compressed_bytes / (double)(1024) << " KiB\n";
+
+		std::cout << "Preparing Preamble and headers\n";
+	}
+
+	// Now fill out the Preamble Info
+	OutputPreambleInfo pinfo;
+	pinfo.HemeLBMagic = HemeLbMagicNumber;         // From gmy.h
+	pinfo.GmyNativeMagic = GmyNativeMagicNumber;   // From gmy.h  
+	pinfo.Version = GmyNativeVersionNumber;        // From gmy.h
+	pinfo.BlocksX = nBlocksX;					   // From earlier calculations
+	pinfo.BlocksY = nBlocksY;
+	pinfo.BlocksZ = nBlocksZ;
+	pinfo.BlockSize = blockDim;				       // We set this as constexpr earlier in the file
+	pinfo.MaxCompressedBytes = global_max_compressed_bytes;			// We computed this (these are per-block quantities so uint32_t is safe)
+	pinfo.MaxUncompressedBytes = global_max_uncompressed_bytes;     // We computed this  (these are per-block quantities so uint32_t is safe)
+	// Header offset is 56 -- default on construction
+	pinfo.NonEmptyBlocks = global_nonempty_blocks;					// We computed this 
+
+	// This is the offset to the data: HeaderOffset is fixed at 56. NonemptyHeaderRecordSize is 28. 
+	pinfo.DataOffset = pinfo.HeaderOffset + pinfo.NonEmptyBlocks*NonemptyHeaderRecordSize;
+	if( this_rank == 0 ) { 
+		std::cout << "Header Size = " << pinfo.NonEmptyBlocks*NonemptyHeaderRecordSize << " bytes = " 
+				   << (double)pinfo.NonEmptyBlocks*NonemptyHeaderRecordSize/(double)(1024*1024) << " MiB\n";
+	}	
+	// Now the headers
+	// We walk the map and unroll it into a vector for writing
+	std::vector<NonEmptyHeaderRecord> local_header( output_info.size() );
+	uint64_t header_idx = 0;
+	for( const auto& kv : output_info )  {
+		local_header[header_idx] = kv.second.header;
+		local_header[header_idx].fileOffset += compressed_offset;
+
+#if 0
+		std::cout << "Rank " << this_rank << " : idx = "<< header_idx 
+				     << " block = " << local_header[header_idx].blockNumber
+		       	  	     << " sites = " << local_header[header_idx].sites
+				     << " comp_bytes = " << local_header[header_idx].bytes 
+				     << " uncomp_bytes = " << local_header[header_idx].uncompressedBytes 
+				     << " offset = " << local_header[header_idx].fileOffset << "\n"; 
+#endif
+		header_idx++;
+	}
+	
+	// Each rank needs to offset its write to not stomp on the other nodes headers. 
+	// We can work out the displacements using an exclusive scan
+	uint64_t header_offset = 0;
+	MPI_Exscan( &header_idx, &header_offset, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD );
+	// Header offset now holds where my rank should wrirte in units of NonEmptyHeaderRecords. 
+	// Let us convert this to bytes
+	header_offset *= NonemptyHeaderRecordSize;  // NB: The size of the struct is 32 from sizeof because of alignment we don't want to pad
+
+	// And let us add on the Preamble offset. 
+	header_offset += pinfo.HeaderOffset;
+
+	// This is just to convert to an MPI_Offset (from uint64_t)
+	MPI_Offset my_header_offset = header_offset; // Offset to start writing our local array
+
+	// Now we will make an MPI type for our header: 6 elements (blocks): 2 uint64_ts, 4 uint32_ts
+	MPI_Datatype header_type;
+	int blen[6] = {1,1,1,1,1,1};  // Number of elements in each 'block'
+	MPI_Aint  bdisp[6] = {0,8,16,20,24,28}; // Displacements of the elements
+
+	MPI_Datatype btypes[6] = { MPI_UINT64_T, MPI_UINT64_T, MPI_UINT32_T, MPI_UINT32_T, MPI_UINT32_T, MPI_UINT32_T };
+	MPI_Type_create_struct( 6, blen, bdisp, btypes, &header_type );
+	MPI_Type_commit(&header_type);
+
+	size_t chunk_size = 2*1024*1024; // 2 MiB transaction size
+	
+
+	// OK. We need to open an output file.
+	if( this_rank == 0 ) std::cout << "Opening and writing SGMY file\n";
+
+	MPI_File out_fh;
+	MPI_File_open(MPI_COMM_WORLD, output_filename.c_str(), MPI_MODE_CREATE |MPI_MODE_WRONLY, MPI_INFO_NULL, &out_fh);
+	double startio = MPI_Wtime();
+	
+	// Now for the IO part
+	// Rank 0 writes the preamble
+	if( this_rank == 0 ) {
+		MPI_Status status;
+		MPI_File_write_at(out_fh, 0, &pinfo, pinfo.HeaderOffset, MPI_BYTE, &status);
+	}
+
+	// Everyone writes the headers using collective write_at_all()
+	// FIXME:  Check return and status
+	
+
+	MPI_Status header_write_status;
+	MPI_File_seek(out_fh, my_header_offset, MPI_SEEK_SET);
+
+	// Use the number of records from the scan
+	MPI_File_write_all(out_fh, local_header.data(), header_idx, header_type, &header_write_status); 
+	// Now write the data. We are going to write a stream of bytes, but we may have that we have over 2GB locally to write.
+	// So unless we make a large type that is hard. However making a large type is also hard because each block may have 
+	// a different compressed length. So we will use a transaction size (2 MiB) in this case and loop with that until 
+	// we reach the end of the data for each rank.
+	// Compressed offset is from the exclusive scan earlier;
+	// Writing loop: we will start writing locally at &outputBuffer[bytes_written] and write bytes_to_write bytes
+	// bytes_to_write will be our chunk size, or a mop-up amount at the end of the data which is less.
+	// Then we increase 'bytes_written' and the start offset by the amount we just wrote.
+	// Finally in principle each process could have different amounts of data, so I will use the "MPI_File_write_at_all" collective MPI I/O routine
+	size_t bytes_written = 0;
+ 	MPI_Offset current_offset = pinfo.DataOffset+compressed_offset;
+	while( bytes_written < rank_compressed_bytes ) {
+
+		// Determine bytes to write
+		size_t bytes_to_write =  ( bytes_written + chunk_size > rank_compressed_bytes ) ? rank_compressed_bytes - bytes_written : chunk_size; 
+
+		// Do the write:
+		// FIXME: Check status
+		MPI_Status mpi_data_write_status;
+		MPI_File_write_at(out_fh, current_offset, &outputBuffer[bytes_written], bytes_to_write, MPI_BYTE, &mpi_data_write_status);
+
+		// Increase bytes_written (start location in our local buffer) 
+		bytes_written += bytes_to_write;
+
+		// Increase offset (start_location in the file)
+		current_offset += bytes_to_write;
+	}
+	// We are done	
+	double endio = MPI_Wtime();
+
+	MPI_File_close(&out_fh);
+	if( this_rank == 0 ) {
+		double io_time = endio-startio;
+		uint64_t size_in_bytes = pinfo.DataOffset + global_compressed_bytes;
+		double size_in_GiB = (double)(size_in_bytes)/(double)(1024*1024*1024);
+		std::cout << "Output IO took: " << endio - startio << " sec. Average BW: " << size_in_GiB/io_time << " GiB/sec. \n";
+		std::cout << "Expected file size = " << size_in_bytes  << " bytes = " << size_in_GiB <<" GiB\n";
+	}	
+}
+
+void processRecordData(RawData& rd)
+{
+	std::map< uint64_t, std::vector< Site* > > local_blocksite_map;
+	/*
+	 * Step 1: Work out size of the Block Grid
+	 */
+	this_rank = rd.this_rank;
+	num_ranks = rd.num_ranks;
+
+	if (this_rank == 0 ) std::cout << "Determining size of block grid\n";
+	double minmaxstart = MPI_Wtime();
+	// First we need to establish max_blocks
+ 	#pragma omp parallel reduction(max: nBlocksX, nBlocksY, nBlocksZ)
+	for(size_t i=0; i < rd.local_num_records; i++) {
+		const Site& sitedata = rd.record_data[i];
+		uint64_t x=sitedata.x;
+		uint64_t y=sitedata.y;
+		uint64_t z=sitedata.z;
+		uint64_t blockX = x/blockDim + 1;
+		uint64_t blockY = y/blockDim + 1;
+		uint64_t blockZ = z/blockDim + 1;
+		if( blockX > nBlocksX ) nBlocksX = blockX;
+		if( blockY > nBlocksY ) nBlocksY = blockY;
+		if( blockZ > nBlocksZ ) nBlocksZ = blockZ;
+	}
+
+	uint64_t local_maxes[3] = { nBlocksX, nBlocksY, nBlocksZ };
+	uint64_t global_maxes[3] = {0,0,0};
+
+	MPI_Allreduce(local_maxes, global_maxes, 3, MPI_UINT64_T, MPI_MAX, MPI_COMM_WORLD);
+	if( this_rank == 0 ) {
+		std::cout << "MaxBlockSizes: " << global_maxes[0] <<  " , " << global_maxes[1] 
+					<< " , " << global_maxes[2] << "\n";
+	}
+	nBlocksX = global_maxes[0];
+	nBlocksY = global_maxes[1];
+	nBlocksZ = global_maxes[2];
+	double minmaxend=MPI_Wtime();
+	if( this_rank == 0 ) std::cout << "Finding block grid dimensions took " << minmaxend - minmaxstart << " sec.\n";
+
+
+	if ( this_rank == 0 ) std::cout << "Beginning Local Insertions:\n";
+
+	/*
+	 * Step 2: Insert each blocksite into the local blocksite map 
+	 */
+	
+	double insertstart=MPI_Wtime();
+	local_blocksite_map.clear();
+
+	// Now go through the array and populate my map
+	for(uint64_t rec_idx=0; rec_idx < rd.record_data.size(); rec_idx++) {
+
+		// Determine block_id and site_id
+		// Coordinates run as: Z, Y, X   with Z slowest
+		uint64_t x=rd.record_data[ rec_idx ].x;
+		uint64_t y=rd.record_data[ rec_idx ].y;
+		uint64_t z=rd.record_data[ rec_idx ].z;
+		uint64_t blockX = x/ blockDim;
+		uint64_t blockY = y/ blockDim;
+		uint64_t blockZ = z/ blockDim;
+		uint64_t siteX = x % blockDim;
+		uint64_t siteY = y % blockDim;
+		uint64_t siteZ = z % blockDim;
+		uint64_t block_id = blockZ + nBlocksZ * (blockY + nBlocksY * blockX);
+		uint64_t site_id = siteZ + blockDim * (siteY + blockDim * siteX);
+
+		// If we have no block in our map	
+		// Insert an empty vector
+		if( local_blocksite_map.find( block_id ) == local_blocksite_map.end() ) {
+			local_blocksite_map.insert( std::pair<uint64_t, std::vector<Site*> >( block_id, std::vector<Site*>()) );
+		}
+
+		// Push back the site id, and the index in the array
+		std::vector<Site*>& the_vec = local_blocksite_map.at(block_id);
+		the_vec.push_back( rd.getPtrToSite(rec_idx) );
+	}
+	double insertend = MPI_Wtime();
+	if( this_rank == 0 ) std::cout << "Local Insertions Completed in " << insertend - insertstart << " sec.\n";
+
+	// Sanity Check: loop through the blocks and count the non-nulls;
+	uint64_t fluid_sites = 0;
+	for( auto& kv : local_blocksite_map ) {
+		fluid_sites += kv.second.size();
+	}
+
+	if( fluid_sites != rd.local_num_records ) {
+		std::cout << "Rank " << this_rank << " : something wrong. Expected " << rd.local_num_records
+			<< " but found only " << fluid_sites << "\n";
+			exit(-1);
+	}
+	MPI_Barrier(MPI_COMM_WORLD); // Wait until all insertions are completed
+	if( this_rank == 0) {
+		std::cout << "Consistency check passed\n"; 
+	} 
+
+	/* *  Step 3: Generate a list of unique local keys as an array */ 
+	// Get Unique Block IDs
+	std::set< uint64_t > global_blockids_set;
+	{
+
+		/* Intermediate step. We need to arrange things so that each rank holds a similar number of blocks 
+		 * The way to do this is to find minimum and maximum block-Ids for each node */
+
+		/* Create a vector of unique local block ids */
+		std::vector<uint64_t> local_blockids;
+		local_blockids.reserve(local_blocksite_map.size());
+		for( const auto& kv : local_blocksite_map ) local_blockids.push_back( kv.first );
+
+		/* Gather the number of unique block_ids for each rank */
+		std::vector<int> blockid_sizes(num_ranks);
+		int my_blockid_size = local_blockids.size();
+		MPI_Allgather(&my_blockid_size, 1, MPI_INT, blockid_sizes.data(), 1, MPI_INT, MPI_COMM_WORLD);
+
+		/* Now gather the blockids themselves using a Gatherv. 
+		   Each Rank will send its unique blockids 
+		   To find out where each unique_blockid should come we need displacements 
+		*/
+	
+		/* We will use total blocks for the size ofthe receive array. Just sum the 
+		   gathered blocksizes */	
+		size_t total_blocks =0;
+		for( auto blocksize : blockid_sizes )  total_blocks += blocksize;
+
+		/* We will compute the displacement of the data from each rank based on blockid_sizes */	
+		std::vector<int> displace( num_ranks );
+		displace[0] = 0;
+		for(int i=1; i < num_ranks; i++) displace[i] = displace[i-1] + blockid_sizes[i-1];
+
+		/* Allocate the receive buffer */
+		std::vector<uint64_t> all_blockids( total_blocks );
+
+		/* Gather the data */	
+		MPI_Allgatherv(local_blockids.data(), local_blockids.size(), MPI_UINT64_T, all_blockids.data(), blockid_sizes.data(), displace.data(), MPI_UINT64_T, MPI_COMM_WORLD);
+
+		/* Now insert al the blockids -- duplicate inserts will fail */
+		for( const auto& blockid : all_blockids ) {
+			global_blockids_set.insert(blockid);
+		}
+	}	
+
+
+	/* Now we have somenew stats */
+	size_t n_blocks_global = global_blockids_set.size();
+	uint64_t n_blocks_per_rank = n_blocks_global/num_ranks;
+	uint64_t n_blocks_last_rank = n_blocks_global - ( n_blocks_per_rank * (num_ranks-1) );
+	uint64_t n_blocks_for_my_rank = ( this_rank == num_ranks-1 ) ? n_blocks_last_rank : n_blocks_per_rank;
+
+	if ( this_rank == 0 ) {
+		std::cout << "Num Unique Blocks: " << n_blocks_global << " Blocks_per_rank: " << n_blocks_per_rank << " Blocks_last_rank: " << n_blocks_last_rank << "\n";
+	}
+
+	/* Now create a vector of the global blockids */
+	const auto& set_iterator = global_blockids_set.begin();
+	std::vector<uint64_t> unique_blockids( global_blockids_set.begin(), global_blockids_set.end());
+	if ( this_rank == 0 ) std::cout << "Global Min Block ID = " << unique_blockids[0] << " Max Block ID = " << unique_blockids[ unique_blockids.size() -1 ] << "\n";
+
+	if( this_rank == 0) std::cout << "Starting data rearrangement\n";
+	if( this_rank == 0) std::cout << "--> Splitting blocks into ranges\n";
+ 
+	/* Now divide this up */
+	std::vector<uint64_t> minblock_for_rank(num_ranks);
+	int index=0;	
+	for(int i=0; i < num_ranks; i++) {
+	   minblock_for_rank[i] = unique_blockids[index];
+	   index += n_blocks_per_rank;
+	}
+
+	if( this_rank == 0) std::cout << "--> reassigning blocks to ranks\n";
+	/* Now each rank has its range:
+		rank = 0...N-2 :   minblock_for_rank[ rank ] <= block < minblock_for_rank[ rank + 1 ]
+		rank = N-1 : minblock_for_rank[N-1] <= block <= global_max_block
+	 */
+	std::map< int, std::vector<Site*> > distribution_map;
+	std::vector< uint64_t > sites_to_rank(num_ranks);
+	for(int i=0; i < num_ranks; i++)  sites_to_rank[i]=0;
+
+	// Go through the local blocksite map
+	for( auto& kv : local_blocksite_map ) {
+	  uint64_t blockid = kv.first;
+
+	  // Find the destination rank
+	  int dest_rank = 0; 
+	  for(int i=1; i < num_ranks; i++) {
+		if( blockid >= minblock_for_rank[i] ) dest_rank++;
+	  }
+
+	  std::vector<Site*>& site_ptrs = kv.second;
+
+	  // Increase the count
+	  sites_to_rank[ dest_rank ] += site_ptrs.size();
+
+	  // Copy over the distribution_map
+	  if( distribution_map.find(dest_rank) == distribution_map.end() ) {
+		distribution_map[ dest_rank ] = std::vector<Site*>();
+	  }
+	  std::vector<Site*>& dist_sites = distribution_map[ dest_rank ];
+	  dist_sites.insert( dist_sites.end(), site_ptrs.begin(), site_ptrs.end() ); 
+	}
+
+	
+	std::vector<uint64_t> displs_to_rank( num_ranks );
+	displs_to_rank[0] = 0;
+	for( int i=1; i < num_ranks; i++) displs_to_rank[i] = displs_to_rank[i-1]+sites_to_rank[i-1];
+
+	std::vector<Site> sites_to_scatter( rd.record_data.size() );
+	uint64_t idx=0;
+	for(const auto& kv : distribution_map ) {
+		std::vector<Site*> site_ptrs = kv.second;
+		for( Site* src_ptr : site_ptrs ) {
+			sites_to_scatter[idx] = *src_ptr; // copy
+			idx++;
+		}
+	}
+
+	local_blocksite_map.clear();
+	distribution_map.clear();
+	rd.record_data.clear();
+
+	// In order to exchange the data. I will need to know how many sites I will get from each other rank. In other
+	// words I need the sites_to_rank arrays from all the ranks
+	std::vector< uint64_t > sites_to_rank_global( num_ranks * num_ranks );
+	{
+		MPI_Allgather( sites_to_rank.data(), num_ranks, MPI_UINT64_T, sites_to_rank_global.data(), num_ranks, MPI_UINT64_T, MPI_COMM_WORLD);
+	}
+
+	if( this_rank == 0 ) std::cout << "--> Communicating the sites to new ranks\n";
+	
+    {
+		// Now we want to do a humongous alltoall. Trouble is something goes wrong here, perhaps 
+		// the displacements get too big? So I am splitting it into O(num_ranks) sendrecvs
+		//
+
+		MPI_Datatype site_mpi_type;
+		MPI_Type_contiguous(rd.record_size, MPI_UINT64_T, &site_mpi_type);
+   		MPI_Type_commit(&site_mpi_type);
+	
+		std::vector<MPI_Request> reqs(2*num_ranks);
+
+		std::vector<uint64_t> rcounts(num_ranks) ;
+		std::vector<uint64_t> rdispls(num_ranks) ;
+
+		uint64_t total_rec = 0;
+		for(int i=0; i < num_ranks; i++) { 
+			rcounts[i]=sites_to_rank_global[this_rank + i*num_ranks];
+			if ( rcounts[i] > std::numeric_limits<int>::max() ) 
+				std::cout << "Rank " << this_rank << " : Receive count over integer size limit from rank " << i << " rcounts[i]=" << rcounts[i] << "\n";
+			total_rec += rcounts[i];
+		}
+
+		rdispls[0]=0;
+		for(int i=1; i < num_ranks; i++) { 
+			rdispls[i] = rdispls[i-1]+rcounts[i-1];
+		}
+
+		// Allocate therearranged data
+		rearranged_data.resize( total_rec );
+
+		// Now set up receives
+		for(int i=0; i < num_ranks; i++) {
+			MPI_Irecv(&rearranged_data[rdispls[i]], (int)rcounts[i], site_mpi_type, i, i, MPI_COMM_WORLD, &reqs[2*i]);
+		}
+
+		// Now set up the sends
+		for(int i=0; i < num_ranks; i++) { 
+			MPI_Isend(&sites_to_scatter[ displs_to_rank[i] ], (int)sites_to_rank[i], site_mpi_type, i, this_rank, MPI_COMM_WORLD, &reqs[2*i+1]);
+		}
+		std::vector<MPI_Status> statii(2*num_ranks);
+		MPI_Waitall(2*num_ranks, reqs.data(), statii.data());
+ 
+	}
+	sites_to_scatter.clear();
+
+	if( this_rank == 0 ) std::cout << "--> Building block map from rearranged data\n";
+	for( const Site& site : rearranged_data ) {
+		uint64_t x=site.x;
+		uint64_t y=site.y;
+		uint64_t z=site.z;
+		uint64_t blockX = x/ blockDim;
+		uint64_t blockY = y/ blockDim;
+		uint64_t blockZ = z/ blockDim;
+		uint64_t siteX = x % blockDim;
+		uint64_t siteY = y % blockDim;
+		uint64_t siteZ = z % blockDim;
+		uint64_t block_id = blockZ + nBlocksZ * (blockY + nBlocksY * blockX);
+		uint64_t site_id = siteZ + blockDim * (siteY + blockDim * siteX);
+
+		bool cond1 = (this_rank < num_ranks-1 ) && ( block_id >= minblock_for_rank[this_rank] ) && (block_id < minblock_for_rank[this_rank + 1] );
+		bool cond2 = (this_rank == num_ranks-1) && ( block_id >= minblock_for_rank[this_rank] );
+		if( ! ( cond1 || cond2 ) ) {
+			std::cout << "Error: Block_id out of range: block_id = " << block_id 
+					  << " min_block_for_rank = " << minblock_for_rank[this_rank]
+					  << " max_block_for_rank = " << (( this_rank < num_ranks-1 ) ? minblock_for_rank[this_rank+1] : std::numeric_limits<uint64_t>::max()) <<"\n";
+			MPI_Abort(MPI_COMM_WORLD,-3);
+		}
+	}
+
+	if ( this_rank == 0 ) std::cout << "Rearrangement completed successfully \n";
+	uint64_t my_sites = rearranged_data.size();
+	uint64_t total_sites = 0;
+	MPI_Allreduce(&my_sites, &total_sites, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
+	if ( total_sites != rd.global_num_records ) { 
+		std::cout << "Rank " << this_rank << " : Error! Rearranged sites dont sum to original.Rearranged sites=" << total_sites << " original read was: " << rd.global_num_records << "\n";
+		MPI_Abort(MPI_COMM_WORLD, -4);
+	}
+ 	if ( this_rank == 0 ) std::cout << "Correct number of rearranged sites" << std::endl;
+}
+
+
+
+
+int main(int argc, char *argv[]) 
+{
+	if( argc != 3 ) {
+	  std::cout << "Usage: linkFileProcessor <fluidsandLinks_file> < SGMY filename>\n";
+	  return -1;
+	}
+	std::string filename_in(argv[1]);
+	std::string filename_out(argv[2]);
+
+	MPI_Init(&argc,&argv);
+	MPI_Comm_rank(MPI_COMM_WORLD,&this_rank);
+	MPI_Comm_size(MPI_COMM_WORLD,&num_ranks);
+	if( this_rank == 0) std::cout << "MPI Initialized: I am rank " << this_rank << " out of " << num_ranks << "\n";
+	RawData raw_records(MPI_COMM_WORLD);
+	raw_records.read(filename_in.c_str());
+
+	if( this_rank == 0) std::cout << "Data read \n" << std::flush;
+	processRecordData(raw_records);
+	convertData(filename_out);
+
+	MPI_Finalize();
+}

--- a/linkFileProcessor/raw_data_reader.hpp
+++ b/linkFileProcessor/raw_data_reader.hpp
@@ -1,0 +1,127 @@
+// Copyright 2024 NVIDIA Corporation.
+// For Copyright and Licensing please refer to the LICENSE and
+// THIRD_PARTY_LICENSES file in the top level directory of this package
+
+#pragma once
+#include <array>
+#include <vector>
+#include <string>
+#include <cstdio>
+#include <cstdint>
+#include <mpi.h>
+
+
+struct Site {
+    uint64_t x;
+    uint64_t y;
+    uint64_t z;
+    std::array< std::array< uint64_t, 6>, 26> link_data;
+};
+
+struct RawData {
+
+    static constexpr uint64_t record_size_in_bytes=sizeof(Site);
+	static constexpr unsigned int record_size=sizeof(Site)/sizeof(uint64_t);
+    std::vector<Site> record_data;
+    size_t global_num_records;
+	size_t local_num_records; 
+	size_t num_records_per_rank;
+	size_t num_records_last_rank; 
+	int this_rank;
+	int num_ranks;
+	MPI_Comm comm;
+
+    RawData(MPI_Comm comm_ = MPI_COMM_WORLD) : 
+		global_num_records(0), 
+		local_num_records(0), 
+		num_records_per_rank(0), 
+		num_records_last_rank(0),
+		comm(comm_) 
+	{
+		MPI_Comm_rank(comm, &this_rank);
+		MPI_Comm_size(comm, &num_ranks);
+	}
+		
+
+	Site* getPtrToSite(uint64_t elem) {
+		if( elem >= record_data.size() ) return nullptr;
+		return &record_data[elem];	
+	}
+
+	
+	// Allocate
+	void allocate(uint64_t n_elem) {
+		record_data.resize(n_elem);
+	}
+
+	// Read data and set members
+    void read(const std::string& filename)
+    {   
+        MPI_File file_in;
+    
+        if( this_rank == 0 ) std::cout << "Opening file " << filename << "\n" << std::flush;
+
+	    int32_t	error = MPI_File_open(comm, filename.c_str(), MPI_MODE_RDONLY, MPI_INFO_NULL, &file_in);
+	    if(error != MPI_SUCCESS) {
+		    fprintf(stderr, "ERROR: Could not open '%s' for reading. Error %d on rank %d.\n", filename.c_str(), error, this_rank);
+		    MPI_Finalize();
+		    exit(1);
+	    }
+        
+        MPI_Offset total_file_size;
+	    // first check that there are an equal number of records in this file
+	    MPI_File_get_size(file_in, &total_file_size);
+	    if(total_file_size % record_size_in_bytes != 0) {
+		    fprintf(stderr, "ERROR: File (size %lld) does not contain a whole number of records (of size %lu).\n", total_file_size, record_size_in_bytes);
+		    MPI_Finalize();
+		    exit(1);
+	    }
+
+	    size_t num_records = total_file_size / record_size_in_bytes;
+	    num_records_per_rank = num_records / num_ranks;
+    	if( num_records % num_ranks != 0 ) num_records_per_rank++;
+		num_records_last_rank = num_records - ( num_ranks - 1 )*num_records_per_rank;
+	
+	    size_t num_records_to_read = 0;
+	    if( this_rank == (num_ranks - 1) ) {
+		    num_records_to_read = num_records_last_rank;
+	    } 
+	    else { 
+		    num_records_to_read = num_records_per_rank;
+	    }
+	    if( this_rank == 0 ) {
+		    std::cout << "Read: total records = " << num_records << "\n";
+		    std::cout << "--> records_per_rank = " << num_records_per_rank << "\n";
+		    std::cout << "--> records_for_last_rank = " << num_records_last_rank << "\n";	
+	    }
+
+	    // record_data.resize(num_records_to_read);
+		allocate(num_records_to_read);
+	    MPI_Status status;  
+        MPI_Datatype raw_record_datatype;
+    	MPI_Type_contiguous(record_size, MPI_UINT64_T, &raw_record_datatype);
+	    MPI_Type_commit(&raw_record_datatype);
+
+	    if( num_records_to_read > std::numeric_limits<int>::max()) {
+		    printf("num_records is bigger than signed int (in readData)\n");
+		    exit(1);
+	    }
+	    double starttime = MPI_Wtime();
+	    MPI_Offset off = num_records_per_rank*this_rank*record_size_in_bytes; //
+	    int count = num_records_to_read;
+	    MPI_File_read_at(file_in, off, (void*)record_data.data(), count, raw_record_datatype, &status);
+	    double endtime = MPI_Wtime();
+
+	    double BW = num_records * record_size_in_bytes / ((double)(1024*1024*1024)*(endtime-starttime));
+	    if( this_rank == 0) {
+		    std::cout << "File read: time = " << (endtime-starttime) << " sec. BW = " << BW << " GB/sec\n";
+	    }
+
+	    global_num_records = num_records;
+	    local_num_records = num_records_to_read;
+		MPI_Type_free(&raw_record_datatype);
+        MPI_File_close(&file_in);
+	
+    }
+
+};


### PR DESCRIPTION
This PR adds the linkFileProcessor and sgmy2inlets contributions. linkFIleProcessor is a new version to replace vx2gmy. It reads the `fluidsAndLinks.dat` file, moves the data around so that all the sites belonging to a block live on the same MPI rank and then compresses and dumps the data into an SGMY file.  This can be somewhat memory intensive.

sgmy2inlets is a drop in replacement for gmy2inlets using the SGMY headers.

a new version of hemeLBpreprocSingle.py called hemeLBpreprocSingleNewTools.py is also provided. 